### PR TITLE
Add ability to provide client side cert file

### DIFF
--- a/docs/description.md
+++ b/docs/description.md
@@ -7,11 +7,11 @@ packageN | package name is defined in .proto | io.grpc.examples.helloworld
 service | the service is defined in .proto | Greeter
 method | rpc method to load test | sayHello
 request | request class name | io.grpc.examples.helloworld.HelloRequest
-timeout | timeout for each call in milisecond | 3000
+timeout | timeout for each call in milliseconds | 3000
 metaData | gRPC interceptor | {"Authorization" : "Bearer TOKEN", "Username": "A"}
 requestBuilderCode | the request message |
 
-`Note:` The requestBuilderCode must follows template below:
+`Note:` The requestBuilderCode must follow the template below:
 
 ```java
 import com.google.protobuf.Message;

--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
 
     <artifactId>jmeter-grpc-client-sampler</artifactId>
     <groupId>vn.zalopay</groupId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <repo-internal-version>0.0.1</repo-internal-version>
-        <grpc.version>1.23.0</grpc.version>
+        <grpc.version>1.33.1</grpc.version>
         <google.protobuf.version>3.9.0</google.protobuf.version>
         <jmeter.core.version>5.1.1</jmeter.core.version>
         <spring.version>4.3.9.RELEASE</spring.version>
@@ -158,8 +158,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.9</source>
+                    <target>1.9</target>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -158,8 +158,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.9</source>
-                    <target>1.9</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.11</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.jmeter</groupId>
             <artifactId>ApacheJMeter_core</artifactId>
             <version>${jmeter.core.version}</version>

--- a/src/main/java/vn/zalopay/jmeter/grpc/client/GrpcClientSampler.java
+++ b/src/main/java/vn/zalopay/jmeter/grpc/client/GrpcClientSampler.java
@@ -41,6 +41,9 @@ public class GrpcClientSampler extends AbstractSampler implements TestBean, Seri
   private boolean useSsl = Config.USE_SSL;
   @Setter
   @Getter
+  private String certFile = Config.CERT_FILE;
+  @Setter
+  @Getter
   private String packageN = Config.PACKAGE_NAME;
   @Setter
   @Getter

--- a/src/main/java/vn/zalopay/jmeter/grpc/client/GrpcClientSamplerBeanInfo.java
+++ b/src/main/java/vn/zalopay/jmeter/grpc/client/GrpcClientSamplerBeanInfo.java
@@ -19,7 +19,7 @@ public class GrpcClientSamplerBeanInfo extends BeanInfoSupport {
   public GrpcClientSamplerBeanInfo() {
     super(GrpcClientSampler.class);
 
-    createPropertyGroup("Server", new String[] { "hostname", "port", "useSsl" });
+    createPropertyGroup("Server", new String[] { "hostname", "port", "useSsl", "certFile" });
     createPropertyGroup("Service", new String[] { "packageN", "service" });
     createPropertyGroup("Execute", new String[] { "method", "request", "timeout", "metaData", "requestBuilderCode" });
 
@@ -31,6 +31,7 @@ public class GrpcClientSamplerBeanInfo extends BeanInfoSupport {
     setPropertyDescriptor(props, "hostname", Config.HOST_NAME);
     setPropertyDescriptor(props, "port", Config.PORT);
     setPropertyDescriptor(props, "useSsl", Config.USE_SSL);
+    setPropertyDescriptor(props, "certFile", Config.CERT_FILE);
     setPropertyDescriptor(props, "packageN", Config.PACKAGE_NAME);
     setPropertyDescriptor(props, "service", Config.SERVICE);
     setPropertyDescriptor(props, "method", Config.METHOD);

--- a/src/main/java/vn/zalopay/jmeter/grpc/utils/Config.java
+++ b/src/main/java/vn/zalopay/jmeter/grpc/utils/Config.java
@@ -9,6 +9,7 @@ public class Config {
   public static final String HOST_NAME = props.getOrDefault("sampler.host", "localhost");
   public static final int PORT = Integer.parseInt(props.getOrDefault("sampler.port", "50051"));
   public static final boolean USE_SSL = Boolean.getBoolean(props.getOrDefault("sampler.use.ssl", "false"));
+  public static final String CERT_FILE = props.getOrDefault("sampler.service.cert.file", "");
   public static final String PACKAGE_NAME = props.getOrDefault("sampler.package.name", "io.grpc.examples.helloworld");
   public static final String SERVICE = props.getOrDefault("sampler.service.name", "Greeter");
   public static final String METHOD = props.getOrDefault("sampler.method.name", "sayHello");

--- a/src/main/java/vn/zalopay/jmeter/grpc/utils/GrpcUtils.java
+++ b/src/main/java/vn/zalopay/jmeter/grpc/utils/GrpcUtils.java
@@ -162,7 +162,7 @@ public class GrpcUtils {
       builder = builder.usePlaintext();
     } else if (!StringUtils.isBlank(sampler.getCertFile())) {
       // build out a managed channel that can accept the ssl cert file
-      // Get the file and verify it exits
+      // Get the file and verify it exists
       File certFile = new File(sampler.getCertFile());
       if (!certFile.exists()) {
         LOGGER.error("The cert file passed in does not exist at: ", sampler.getCertFile());

--- a/src/main/java/vn/zalopay/jmeter/grpc/utils/GrpcUtils.java
+++ b/src/main/java/vn/zalopay/jmeter/grpc/utils/GrpcUtils.java
@@ -8,6 +8,7 @@ import com.google.protobuf.util.JsonFormat;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.handler.ssl.SslContext;
+import org.apache.commons.lang3.StringUtils;
 import vn.zalopay.jmeter.grpc.client.GrpcClientInterceptor;
 import vn.zalopay.jmeter.grpc.client.GrpcClientSampler;
 import vn.zalopay.jmeter.grpc.compiler.StringGeneratedJavaCompilerFacade;
@@ -159,7 +160,7 @@ public class GrpcUtils {
 
     if (!sampler.isUseSsl()) {
       builder = builder.usePlaintext();
-    } else if (!sampler.getCertFile().isEmpty()) {
+    } else if (!StringUtils.isBlank(sampler.getCertFile())) {
       // build out a managed channel that can accept the ssl cert file
       // Get the file and verify it exits
       File certFile = new File(sampler.getCertFile());

--- a/src/main/resources/vn/zalopay/jmeter/grpc/client/GrpcClientSamplerResources.properties
+++ b/src/main/resources/vn/zalopay/jmeter/grpc/client/GrpcClientSamplerResources.properties
@@ -9,6 +9,9 @@ port.shortDescription=Port for this server to listen
 useSsl.displayName=useSsl
 useSsl.shortDescription=is server use Ssl
 
+certFile.displayName=certFile
+certFile.shortDescription=path of the cert file
+
 packageN.displayName=packageN
 packageN.shortDescription=package name
 


### PR DESCRIPTION
My testing required the ability to pass a client side cert which was missing from the implementation. These changes allow you to use ssl in two different ways now.

1. Use ssl as it was before these changes works exactly the same if you set UseSsl to true and leave the cert file path empty.
2. Use ssl with a client side cert by setting UseSsl to true and add a path to the cert file.

If there is a better way to do this please let me know and I will update the changes.

These changes also bump up to the latest versions of grpc.