### PR TITLE
Adding extra configuration properties for ManagedChannel

### DIFF
--- a/docs/description.md
+++ b/docs/description.md
@@ -3,6 +3,10 @@ Name | Description | Example
 hostname | service host | 127.0.0.1
 port | service port | 50051
 useSsl | use ssl or not | false
+keepAliveTime | keep alive time in milliseconds | 30000
+keepAliveTimeout | keep alive time out in milliseconds | 30000
+keepAliveWithoutCalls | send keep alive messages without calls | false
+maxInboundMessageSize | max size of inbound message in bytes | 4096
 packageN | package name is defined in .proto | io.grpc.examples.helloworld
 service | the service is defined in .proto | Greeter
 method | rpc method to load test | sayHello

--- a/src/main/java/vn/zalopay/jmeter/grpc/client/GrpcClientSampler.java
+++ b/src/main/java/vn/zalopay/jmeter/grpc/client/GrpcClientSampler.java
@@ -1,29 +1,24 @@
 package vn.zalopay.jmeter.grpc.client;
 
 import com.google.protobuf.Message;
-
-import vn.zalopay.jmeter.grpc.utils.Config;
-import vn.zalopay.jmeter.grpc.utils.GrpcUtils;
-import vn.zalopay.jmeter.grpc.utils.MessageBuilder;
-
 import io.grpc.ManagedChannel;
 import io.grpc.stub.AbstractStub;
-
-import java.io.Serializable;
-import java.lang.reflect.Method;
-import java.util.concurrent.TimeUnit;
-
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.jmeter.samplers.AbstractSampler;
 import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.threads.JMeterContextService;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import vn.zalopay.jmeter.grpc.utils.Config;
+import vn.zalopay.jmeter.grpc.utils.GrpcUtils;
+import vn.zalopay.jmeter.grpc.utils.MessageBuilder;
 
-import lombok.Getter;
-import lombok.Setter;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
 
 public class GrpcClientSampler extends AbstractSampler implements TestBean, Serializable {
 
@@ -63,6 +58,18 @@ public class GrpcClientSampler extends AbstractSampler implements TestBean, Seri
   @Setter
   @Getter
   private String requestBuilderCode = Config.REQUEST_CODE;
+  @Setter
+  @Getter
+  private boolean keepAliveWithoutCalls = Config.KEEP_ALIVE_WITHOUT_CALLS;
+  @Setter
+  @Getter
+  private long keepAliveTime = Config.KEEP_ALIVE_TIME;
+  @Setter
+  @Getter
+  private long keepAliveTimeout = Config.KEEP_ALIVE_TIMEOUT;
+  @Setter
+  @Getter
+  private int maxInboundSizeMessage = Config.MAX_INBOUND_SIZE_MESSAGE;
 
   private transient ManagedChannel channel = null;
   private transient AbstractStub<?> blockingStub = null;

--- a/src/main/java/vn/zalopay/jmeter/grpc/client/GrpcClientSamplerBeanInfo.java
+++ b/src/main/java/vn/zalopay/jmeter/grpc/client/GrpcClientSamplerBeanInfo.java
@@ -1,9 +1,10 @@
 package vn.zalopay.jmeter.grpc.client;
 
-import java.beans.PropertyDescriptor;
-import vn.zalopay.jmeter.grpc.utils.Config;
 import org.apache.jmeter.testbeans.BeanInfoSupport;
 import org.apache.jmeter.testbeans.gui.TypeEditor;
+import vn.zalopay.jmeter.grpc.utils.Config;
+
+import java.beans.PropertyDescriptor;
 
 public class GrpcClientSamplerBeanInfo extends BeanInfoSupport {
 
@@ -19,7 +20,8 @@ public class GrpcClientSamplerBeanInfo extends BeanInfoSupport {
   public GrpcClientSamplerBeanInfo() {
     super(GrpcClientSampler.class);
 
-    createPropertyGroup("Server", new String[] { "hostname", "port", "useSsl", "certFile" });
+    createPropertyGroup("Server", new String[] { "hostname", "port", "useSsl", "certFile", "keepAliveTime",
+        "keepAliveTimeout", "keepAliveWithoutCalls", "maxInboundSizeMessage" });
     createPropertyGroup("Service", new String[] { "packageN", "service" });
     createPropertyGroup("Execute", new String[] { "method", "request", "timeout", "metaData", "requestBuilderCode" });
 

--- a/src/main/java/vn/zalopay/jmeter/grpc/utils/Config.java
+++ b/src/main/java/vn/zalopay/jmeter/grpc/utils/Config.java
@@ -9,6 +9,12 @@ public class Config {
   public static final String HOST_NAME = props.getOrDefault("sampler.host", "localhost");
   public static final int PORT = Integer.parseInt(props.getOrDefault("sampler.port", "50051"));
   public static final boolean USE_SSL = Boolean.getBoolean(props.getOrDefault("sampler.use.ssl", "false"));
+  public static final boolean KEEP_ALIVE_WITHOUT_CALLS = Boolean
+      .getBoolean(props.getOrDefault("sampler.keep.alive.without.calls", "false"));
+  public static final long KEEP_ALIVE_TIME = Long.parseLong(props.getOrDefault("sampler.keep.alive.time", "-1"));
+  public static final long KEEP_ALIVE_TIMEOUT = Long.parseLong(props.getOrDefault("sampler.keep.alive.timeout", "-1"));
+  public static final int MAX_INBOUND_SIZE_MESSAGE = Integer
+      .parseInt(props.getOrDefault("sampler.max.inbound.size.message", "-1"));
   public static final String CERT_FILE = props.getOrDefault("sampler.service.cert.file", "");
   public static final String PACKAGE_NAME = props.getOrDefault("sampler.package.name", "io.grpc.examples.helloworld");
   public static final String SERVICE = props.getOrDefault("sampler.service.name", "Greeter");

--- a/src/main/java/vn/zalopay/jmeter/grpc/utils/GrpcUtils.java
+++ b/src/main/java/vn/zalopay/jmeter/grpc/utils/GrpcUtils.java
@@ -5,29 +5,30 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
-import io.grpc.netty.GrpcSslContexts;
-import io.grpc.netty.NettyChannelBuilder;
-import io.netty.handler.ssl.SslContext;
-import org.apache.commons.lang3.StringUtils;
-import vn.zalopay.jmeter.grpc.client.GrpcClientInterceptor;
-import vn.zalopay.jmeter.grpc.client.GrpcClientSampler;
-import vn.zalopay.jmeter.grpc.compiler.StringGeneratedJavaCompilerFacade;
 import io.grpc.Channel;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.AbstractStub;
+import io.netty.handler.ssl.SslContext;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import vn.zalopay.jmeter.grpc.client.GrpcClientInterceptor;
+import vn.zalopay.jmeter.grpc.client.GrpcClientSampler;
+import vn.zalopay.jmeter.grpc.compiler.StringGeneratedJavaCompilerFacade;
 
 import javax.net.ssl.SSLException;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.List;
 import java.util.Arrays;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class GrpcUtils {
 
@@ -156,7 +157,20 @@ public class GrpcUtils {
     Map<String, String> headerMap = createHeaderMap(sampler.getMetaData());
 
     ManagedChannelBuilder builder = NettyChannelBuilder.forAddress(sampler.getHostname(), sampler.getPort())
+        .keepAliveWithoutCalls(sampler.isKeepAliveWithoutCalls())
         .intercept(new GrpcClientInterceptor(headerMap, sampler.getTimeout()));
+
+    if (sampler.getKeepAliveTime() >= 0) {
+      builder.keepAliveTime(sampler.getKeepAliveTime(), TimeUnit.MILLISECONDS);
+    }
+
+    if (sampler.getKeepAliveTimeout() >= 0) {
+      builder.keepAliveTimeout(sampler.getKeepAliveTimeout(), TimeUnit.MILLISECONDS);
+    }
+
+    if (sampler.getMaxInboundSizeMessage() >= 0) {
+      builder.maxInboundMessageSize(sampler.getMaxInboundSizeMessage());
+    }
 
     if (!sampler.isUseSsl()) {
       builder = builder.usePlaintext();

--- a/src/main/resources/vn/zalopay/jmeter/grpc/client/GrpcClientSamplerResources.properties
+++ b/src/main/resources/vn/zalopay/jmeter/grpc/client/GrpcClientSamplerResources.properties
@@ -9,6 +9,18 @@ port.shortDescription=Port for this server to listen
 useSsl.displayName=useSsl
 useSsl.shortDescription=is server use Ssl
 
+keepAliveTime.displayName=keepAliveTime
+keepAliveTime.shortDescription=keep alive time in milliseconds
+
+keepAliveTimeout.displayName=keepAliveTimeout
+keepAliveTimeout.shortDescription=keep alive timeout in milliseconds
+
+keepAliveWithoutCalls.displayName=keepAliveWithoutCalls
+keepAliveWithoutCalls.shortDescription=send keep alive messages without calls
+
+maxInboundMessageSize.displayName=maxInboundMessageSize
+maxInboundMessageSize.shortDescription=max size of inbound message in bytes
+
 certFile.displayName=certFile
 certFile.shortDescription=path of the cert file
 
@@ -25,7 +37,7 @@ request.displayName=request
 request.shortDescription=request message type
 
 timeout.displayName=timeout
-timeout.shortDescription=deadline call in milisecond
+timeout.shortDescription=deadline call in milliseconds
 
 
 metaData.displayName=metaData


### PR DESCRIPTION
Following channel properties were added:
 - keepAliveTime: keep alive time in milliseconds
 - keepAliveTimeout: keep alive timeout in milliseconds
 - keepAliveWithoutCalls: send keep alive messages without calls
 - maxInboundMessageSize:  max size of inbound message in bytes

Authors:
- @vkea95
- @megasolis
- @Alexramz